### PR TITLE
TransitionMatrix/compute.real giving unexpected results: levels in multistrata model rearranged when converted to factor

### DIFF
--- a/RMark/R/compute.real.R
+++ b/RMark/R/compute.real.R
@@ -188,9 +188,22 @@ vcv.real=deriv.real%*%model$results$beta.vcv%*%t(deriv.real)
 	{
 		pseudo.real[fixedparms]=0
 		pseudo.real[ind][fixedparms[ind]]=exp(pseudo.real[ind][fixedparms[ind]])
-		sums=by(pseudo.real[ind],model$links[ind],sum)
+		# sums=by(pseudo.real[ind],model$links[ind],sum)
+		
+		# replacement keeps levels in original order, 
+		# otherwise by function creates factor out of character that rearranges
+		# the order, only noticeably if >10 levels because factor will order as 
+		# 1, 10, 11, 2, 3, 4...
+		sums = by(pseudo.real[ind], factor(model$links[ind], levels = unique(model$links[ind])), sum)
+		
 		sums=sums[match(model$links[ind],names(sums))]
-		real[ind]=pseudo.real[ind]/(1+sums[ind])
+		
+		# real[ind]=pseudo.real[ind]/(1+sums[ind])
+		# sums is already of correct length, [ind] gives error because it refers
+		# to indices outside the size of sums vector
+		# I could be wrong, though.
+		real[ind]=pseudo.real[ind]/(1+sums)
+		
 		real[fixedparms]=fixedvalues[fixedparms]
 	}
 #


### PR DESCRIPTION
TransitionMatrix was not extracting model estimates for Psi correctly for a multistrata model with 14 strata (with many transitions fixed to zero). I traced the problem to the compute.real function, where the levels were rearranged when a character vector was converted to a factor in the 'by' function. This misaligned indices and improperly assigned NA's to real parameters.

Changing these two lines keeps the original order of model$links levels and TransitionMatrix then works as expected.

Please let me know if you'd like more details. This is my first pull request, so forgive me if the format or process was done clumsily. Thank you for the RMark package, it's been really helpful.
