### PR TITLE
allow '*0' entries in zero-inflated Poisson mark-resight models

### DIFF
--- a/RMark/R/process.data.R
+++ b/RMark/R/process.data.R
@@ -312,10 +312,15 @@ robust.occasions<-function(times)
                if(substr(model,1,6)!="RDBark" & !(model%in%c("RDBarkHug","Barker","MSOccupancy","PoissonMR","UnIdPoissonMR","PoissonMRacross","UnIdPoissonMRacross","ZiUnIdPoissonMRwithin","ZiUnIdPoissonMRacross")))
                   stop(paste("\nIncorrect ch values in data:",paste(ch.values,collapse=""),"\n",sep=""))
                else
-				  if(model%in%c("PoissonMR","UnIdPoissonMR","PoissonMRacross","UnIdPoissonMRacross","ZiUnIdPoissonMRwithin","ZiUnIdPoissonMRacross"))
-				  {			  
-					  if(any(!ch.values%in%c(".",as.character(0:9),"+","-")))
-						  stop(paste("\nIncorrect ch values in data:",paste(ch.values,collapse=""),"\n",sep=""))
+                 if(model%in%c("PoissonMR","UnIdPoissonMR","PoissonMRacross","UnIdPoissonMRacross"))
+                 {			  
+                   if(any(!ch.values%in%c(".",as.character(0:9),"+","-")))
+                     stop(paste("\nIncorrect ch values in data:",paste(ch.values,collapse=""),"\n",sep=""))
+                 } else
+                   if(model%in%c("ZiUnIdPoissonMRwithin","ZiUnIdPoissonMRacross"))
+                   {			  
+                     if(any(!ch.values%in%c(".",as.character(0:9),"+","-","*")))
+                       stop(paste("\nIncorrect ch values in data:",paste(ch.values,collapse=""),"\n",sep=""))
 				  } else
 				  {
 				      if(any(!ch.values%in%c(".","0","1","2")))


### PR DESCRIPTION
…to indicate marked individuals known to be alive but unobservable (e.g. due to temporary emigration) when the number of marks is known